### PR TITLE
Add LLM-assisted Claude PR review workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+# Pull Request
+
+## Summary
+
+<!-- 1-3 sentences describing what this PR changes and why. Link the user story. -->
+
+## User story
+
+<!-- e.g. US11 / US12 / US13. Link to user-stories.md section if applicable. -->
+
+## How I tested
+
+<!-- Commands you ran locally, manual steps, etc. -->
+
+- [ ] `npx tsc --noEmit`
+- [ ] `npm test` (API)
+- [ ] `cd frontend && npm test && npm run build`
+
+## Reviewer checklist
+
+- [ ] CI (`.github/workflows/ci.yml`) is green.
+- [ ] The **Claude automated code review** comment has been posted on this PR.
+      Re-run it by commenting `/claude-review` if the diff has changed.
+- [ ] I have read the Claude findings and either addressed them or left a
+      reply explaining why each is not actionable. The LLM output is
+      **advisory** — human approval is still required.
+- [ ] At least one human reviewer has approved.

--- a/.github/scripts/README.md
+++ b/.github/scripts/README.md
@@ -1,0 +1,68 @@
+# Claude PR review
+
+Automated, LLM-assisted code review that runs on every pull request.
+
+## How it's triggered
+
+The workflow [`claude-review.yml`](../workflows/claude-review.yml) runs on three events:
+
+| Trigger | When it fires |
+|---|---|
+| `pull_request` (`opened`, `synchronize`, `reopened`) | Any PR is opened or pushed to |
+| `issue_comment` containing `/claude-review` | A reviewer asks for a re-run on an existing PR |
+| `workflow_dispatch` with a `pr_number` input | Manual/retroactive run from the Actions tab |
+
+## Where the output appears
+
+1. **PR comment** — posted by `github-actions[bot]` under the header
+   `### Claude automated code review`. Re-runs update the same comment in place
+   (kept stable via the `<!-- claude-pr-review -->` HTML marker).
+2. **Workflow artifact** — `claude-review-pr-<N>` on the Actions run page,
+   containing the raw diff sent to the model and the Markdown response.
+3. **Workflow logs** — the `Run Claude review` step in the run log.
+
+## What the review contains
+
+The script in [`claude-review.mjs`](./claude-review.mjs) sends the PR title,
+description, changed-file list, and unified diff to `claude-opus-4-7` with a
+system prompt that forces a fixed section layout:
+
+- **Summary** — 2-3 sentences
+- **Risk assessment** — Low / Medium / High + justification
+- **Findings** — numbered list, each tagged `[blocker] / [major] / [minor] / [nit]`, citing `file:line`
+- **Test coverage** — whether tests were added and what's missing
+- **Security** — injection / authz / secrets / validation
+- **Suggested follow-ups** — non-blocking nice-to-haves
+
+The diff is capped at ~200 KB so large PRs don't blow the model's input budget.
+
+## Human judgment
+
+This workflow is **advisory only**. The PR template (`.github/pull_request_template.md`)
+requires a human reviewer to:
+
+1. Read the Claude comment.
+2. Accept, reject, or annotate each finding.
+3. Approve the PR themselves before merge.
+
+Merges still go through the normal GitHub review + CI gates — the Claude
+comment is one input, not an approval.
+
+## Setup (one-time, repo admin)
+
+1. Create an Anthropic API key at <https://console.anthropic.com/>.
+2. In the GitHub repo: **Settings → Secrets and variables → Actions →
+   New repository secret**. Name: `ANTHROPIC_API_KEY`. Value: the key.
+3. The workflow already has `permissions: pull-requests: write` so no further
+   config is needed.
+
+If the secret is missing, the workflow still runs and posts a comment
+explaining the setup step — it never silently fails.
+
+## Re-running on a merged PR
+
+```bash
+# from the Actions tab, pick "Claude PR Review" → "Run workflow"
+# and supply the PR number as input. Or:
+gh workflow run claude-review.yml -f pr_number=53
+```

--- a/.github/scripts/claude-review.mjs
+++ b/.github/scripts/claude-review.mjs
@@ -1,0 +1,121 @@
+// Structured PR review script — called from .github/workflows/claude-review.yml.
+//
+// Reads the PR diff + file list from disk, asks Claude for a structured review,
+// and writes the Markdown result to OUTPUT_PATH so the workflow can post it as
+// a PR comment and/or upload it as an artifact.
+//
+// The prompt intentionally enforces a fixed section layout so reviewers see
+// consistent output across PRs and can compare runs across stories.
+
+import fs from "node:fs";
+import Anthropic from "@anthropic-ai/sdk";
+
+const {
+  ANTHROPIC_API_KEY,
+  PR_NUMBER = "",
+  PR_TITLE = "",
+  PR_BODY = "",
+  PR_HEAD_REF = "",
+  DIFF_PATH = ".claude-review/diff.patch",
+  FILES_PATH = ".claude-review/files.txt",
+  OUTPUT_PATH = ".claude-review/review.md",
+} = process.env;
+
+if (!ANTHROPIC_API_KEY) {
+  writeFallback(
+    "ANTHROPIC_API_KEY is not set on this repository. Add it under " +
+      "*Settings → Secrets and variables → Actions* to enable automated review."
+  );
+  process.exit(0);
+}
+
+const diff = safeRead(DIFF_PATH);
+const files = safeRead(FILES_PATH);
+
+if (!diff.trim()) {
+  writeFallback("No diff detected between the PR base and head — nothing to review.");
+  process.exit(0);
+}
+
+const systemPrompt = `You are a senior software engineer performing a code review on a
+GitHub pull request for the "match-point" project (a fighting-game tournament hub:
+TypeScript/Node Express API + Vitest tests, plus a frontend).
+
+Produce a concise review in GitHub-flavored Markdown with EXACTLY these sections,
+in this order, and no others:
+
+**Summary** — 2-3 sentences describing what this PR does.
+**Risk assessment** — one of: Low / Medium / High, plus a one-line justification.
+**Findings** — a numbered list. Each item is a single finding in the form:
+  \`N. [severity] path/to/file:line — what's wrong and the suggested fix.\`
+  Use severity tags: [blocker], [major], [minor], [nit]. If there are no
+  findings of a given severity, omit them. If there are no findings at all,
+  write "No issues found."
+**Test coverage** — comment on whether tests were added/updated and whether
+  edge cases look covered. Flag missing tests as [major] findings above.
+**Security** — call out injection, authz, secrets, or input-validation issues.
+  If none, write "No security concerns identified."
+**Suggested follow-ups** — optional bullet list of nice-to-haves that should
+  NOT block merge.
+
+Rules:
+- Be specific: cite file paths and line numbers from the diff.
+- Do not restate the diff. Do not praise. Do not hedge with "consider maybe".
+- If the diff is truncated or unclear, say so explicitly in Summary.
+- Keep the whole review under ~500 words.`;
+
+const userPrompt = `PR #${PR_NUMBER}: ${PR_TITLE}
+Branch: ${PR_HEAD_REF}
+
+PR description:
+${PR_BODY || "(no description provided)"}
+
+Changed files (git diff --name-status):
+\`\`\`
+${files || "(empty)"}
+\`\`\`
+
+Unified diff (may be truncated to ~200KB):
+\`\`\`diff
+${diff}
+\`\`\``;
+
+const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
+
+try {
+  const resp = await client.messages.create({
+    model: "claude-opus-4-7",
+    max_tokens: 2000,
+    system: systemPrompt,
+    messages: [{ role: "user", content: userPrompt }],
+  });
+  const text = resp.content
+    .filter((b) => b.type === "text")
+    .map((b) => b.text)
+    .join("\n")
+    .trim();
+  if (!text) {
+    writeFallback("Claude returned an empty response.");
+  } else {
+    fs.writeFileSync(OUTPUT_PATH, text);
+  }
+} catch (err) {
+  const msg = err && err.message ? err.message : String(err);
+  writeFallback(`Claude API call failed: ${msg}`);
+  // Still exit 0 — we want the comment to post rather than fail the workflow.
+}
+
+function safeRead(p) {
+  try {
+    return fs.readFileSync(p, "utf8");
+  } catch {
+    return "";
+  }
+}
+
+function writeFallback(reason) {
+  fs.writeFileSync(
+    OUTPUT_PATH,
+    `**Summary** — Automated review was skipped.\n\n**Reason** — ${reason}`
+  );
+}

--- a/.github/scripts/claude-review.mjs
+++ b/.github/scripts/claude-review.mjs
@@ -84,7 +84,9 @@ const client = new Anthropic({ apiKey: ANTHROPIC_API_KEY });
 
 try {
   const resp = await client.messages.create({
-    model: "claude-opus-4-7",
+    // Haiku is ~10x cheaper than Opus and produces solid structured reviews.
+    // Override by setting the CLAUDE_REVIEW_MODEL env var in the workflow.
+    model: process.env.CLAUDE_REVIEW_MODEL || "claude-haiku-4-5-20251001",
     max_tokens: 2000,
     system: systemPrompt,
     messages: [{ role: "user", content: userPrompt }],

--- a/.github/scripts/package.json
+++ b/.github/scripts/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "claude-review-script",
+  "private": true,
+  "type": "module",
+  "description": "Helper script that calls the Anthropic API to produce a structured PR review.",
+  "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.0"
+  }
+}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,162 @@
+name: Claude PR Review
+
+# Automated LLM-assisted code review.
+# Triggers on every PR (opened / updated / reopened) and when a maintainer
+# posts the comment "/claude-review" on an existing PR. Sends the PR diff and
+# changed-file list to the Anthropic API with a structured review prompt, then
+# posts the result back as a PR comment.
+#
+# Human judgment: this is advisory only. Merges still require human approval
+# per the repo's branch protection / PR template.
+#
+# Required repo secret: ANTHROPIC_API_KEY
+# Required permissions (set below): pull-requests: write, contents: read
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to review (for retroactive runs)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+  issues: write
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.issue.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    # Skip comment trigger unless it's on a PR and the body contains "/claude-review"
+    if: |
+      github.event_name == 'pull_request' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'issue_comment' &&
+       github.event.issue.pull_request != null &&
+       contains(github.event.comment.body, '/claude-review'))
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Resolve PR number
+        id: pr
+        uses: actions/github-script@v7
+        with:
+          script: |
+            let num;
+            if (context.eventName === 'pull_request') {
+              num = context.payload.pull_request.number;
+            } else if (context.eventName === 'issue_comment') {
+              num = context.payload.issue.number;
+            } else {
+              num = parseInt(context.payload.inputs.pr_number, 10);
+            }
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: num,
+            });
+            core.setOutput('number', String(num));
+            core.setOutput('head_sha', pr.head.sha);
+            core.setOutput('base_sha', pr.base.sha);
+            core.setOutput('head_ref', pr.head.ref);
+            core.setOutput('title', pr.title);
+            core.setOutput('body', pr.body || '');
+
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.pr.outputs.head_sha }}
+          fetch-depth: 0
+
+      - name: Collect diff and file list
+        id: diff
+        run: |
+          set -euo pipefail
+          mkdir -p .claude-review
+          BASE="${{ steps.pr.outputs.base_sha }}"
+          HEAD="${{ steps.pr.outputs.head_sha }}"
+          git fetch origin "$BASE" --depth=1 || true
+          # Cap the diff at ~200KB so we stay within model input budget.
+          git diff --no-color "$BASE"..."$HEAD" | head -c 200000 > .claude-review/diff.patch
+          git diff --name-status "$BASE"..."$HEAD" > .claude-review/files.txt
+          echo "bytes=$(wc -c < .claude-review/diff.patch)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install reviewer dependencies
+        working-directory: .github/scripts
+        run: npm install --no-audit --no-fund
+
+      - name: Run Claude review
+        id: claude
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          PR_TITLE: ${{ steps.pr.outputs.title }}
+          PR_BODY: ${{ steps.pr.outputs.body }}
+          PR_HEAD_REF: ${{ steps.pr.outputs.head_ref }}
+          DIFF_PATH: .claude-review/diff.patch
+          FILES_PATH: .claude-review/files.txt
+          OUTPUT_PATH: .claude-review/review.md
+        run: node .github/scripts/claude-review.mjs
+
+      - name: Upload review as artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-review-pr-${{ steps.pr.outputs.number }}
+          path: .claude-review/
+          if-no-files-found: warn
+
+      - name: Post review comment
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const prNumber = parseInt('${{ steps.pr.outputs.number }}', 10);
+            let body;
+            try {
+              body = fs.readFileSync('.claude-review/review.md', 'utf8');
+            } catch {
+              body = '_Claude review failed to produce output. See workflow logs._';
+            }
+            const header = '<!-- claude-pr-review -->\n### Claude automated code review\n\n';
+            const footer = '\n\n---\n_Advisory only — a human reviewer still approves the merge. Re-run with `/claude-review` in a comment._';
+            const full = header + body + footer;
+
+            // Update the existing bot comment if one exists, otherwise create.
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const prior = comments.find(c => c.body && c.body.includes('<!-- claude-pr-review -->'));
+            if (prior) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: prior.id,
+                body: full,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body: full,
+              });
+            }

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -71,11 +71,19 @@ jobs:
             core.setOutput('title', pr.title);
             core.setOutput('body', pr.body || '');
 
-      - name: Checkout PR head
+      - name: Checkout base + PR refs
         uses: actions/checkout@v4
         with:
-          ref: ${{ steps.pr.outputs.head_sha }}
+          # We check out the default branch and then fetch both the base and
+          # the PR head as refs — this works even for merged PRs whose head
+          # branches have been deleted (GitHub keeps refs/pull/N/head around).
           fetch-depth: 0
+
+      - name: Fetch PR head ref
+        run: |
+          set -euo pipefail
+          git fetch origin "pull/${{ steps.pr.outputs.number }}/head:pr-head"
+          git fetch origin "${{ steps.pr.outputs.base_sha }}" --depth=1 || true
 
       - name: Collect diff and file list
         id: diff
@@ -84,7 +92,6 @@ jobs:
           mkdir -p .claude-review
           BASE="${{ steps.pr.outputs.base_sha }}"
           HEAD="${{ steps.pr.outputs.head_sha }}"
-          git fetch origin "$BASE" --depth=1 || true
           # Cap the diff at ~200KB so we stay within model input budget.
           git diff --no-color "$BASE"..."$HEAD" | head -c 200000 > .claude-review/diff.patch
           git diff --name-status "$BASE"..."$HEAD" > .claude-review/files.txt

--- a/README.md
+++ b/README.md
@@ -9,8 +9,17 @@ Automated tests run on **pull requests** and on **pushes** to `main`, `master`, 
 | Workflow | What it runs |
 |----------|----------------|
 | [`.github/workflows/ci.yml`](.github/workflows/ci.yml) | `npx tsc --noEmit`, `npm test` (API / Vitest), `frontend`: `npm test`, `npm run build` |
+| [`.github/workflows/claude-review.yml`](.github/workflows/claude-review.yml) | LLM-assisted code review — calls the Anthropic API with a structured prompt and posts the result as a PR comment |
 
 The API test suite includes **US12 (match-call notifications)** in `src/notifications.test.ts` (Vitest + Supertest against the real Express app).
+
+## Automated code review
+
+Every PR also gets an **automated Claude review** posted as a PR comment (see
+[`.github/scripts/README.md`](.github/scripts/README.md) for details on how it's
+triggered, where the output lives, and how to re-run it on a merged PR). The
+review is **advisory** — a human reviewer still approves merges per the PR
+template.
 
 ## Local checks (same gates as CI)
 


### PR DESCRIPTION
## Summary

Adds an automated, LLM-assisted code review that runs on every pull request.
Satisfies the "Automated code review" requirement (Unit 5, 200 pts) so we can
point to a repeatable workflow for US11, US12, and US13.

## What this adds

- **[`.github/workflows/claude-review.yml`](.github/workflows/claude-review.yml)** — triggers on:
  - `pull_request` (opened / synchronize / reopened)
  - `issue_comment` containing `/claude-review` (for re-runs)
  - `workflow_dispatch` with a `pr_number` input (for retroactive runs on
    merged PRs — e.g. the already-merged US11/US12/US13 PRs)
- **[`.github/scripts/claude-review.mjs`](.github/scripts/claude-review.mjs)** — calls the Anthropic API
  with a structured system prompt that forces a fixed review layout:
  Summary / Risk / Findings / Test coverage / Security / Follow-ups.
  Findings are tagged `[blocker] / [major] / [minor] / [nit]` and cite `file:line`.
- **[`.github/pull_request_template.md`](.github/pull_request_template.md)** — makes the human-approval gate
  explicit: the Claude output is advisory; a human reviewer still signs off.
- **[`.github/scripts/README.md`](.github/scripts/README.md)** — how the workflow is triggered, where
  the output appears, and how to re-run retroactively.
- README row added so the new workflow is discoverable.

## How output appears

1. A single PR comment (updated in place on re-runs, tagged with a hidden
   `<!-- claude-pr-review -->` marker).
2. A workflow artifact `claude-review-pr-<N>` with the raw diff sent to the
   model and the Markdown response — suitable for attaching as a "chat log".
3. The Actions run log itself.

## Repeatability

Teammates / staff can see how a review was triggered by looking at the
workflow file, the Actions tab, or the `/claude-review` comment on the PR.

## Human judgment

The Claude output is advisory only. The PR template requires a human
reviewer to read the findings, accept/reject each one, and approve the PR
before merge. Existing CI (`ci.yml`) still runs the test gates.

## Config

Defaults to `claude-haiku-4-5-20251001` to keep cost low (override via
`CLAUDE_REVIEW_MODEL` env var). Requires one repo secret: `ANTHROPIC_API_KEY`.
If the secret is missing, the workflow still runs and posts a comment
explaining the missing setup step — it does not silently fail.

## Test plan

- [ ] CI is green on this PR.
- [ ] The new "Claude PR Review" workflow runs on this PR and posts a
      comment. Without the secret set yet, the comment will read
      "Automated review was skipped — ANTHROPIC_API_KEY is not set" — this
      proves the wiring end-to-end.
- [ ] After adding the secret, comment `/claude-review` on this PR to see
      a real review.
- [ ] After merge, run the workflow manually from the Actions tab with
      `pr_number=53` (US11), `51` (US12), `50` (US13) to post Claude
      reviews on each story's PR for the writeup.
